### PR TITLE
Partial support for :unix as a supported `base_os`

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,9 @@
 # limitations under the License.
 #
 
-require "bundler/gem_tasks"
+require "bundler/gem_helper"
+
+Bundler::GemHelper.install_tasks(name: "chef-core")
 
 task default: [:spec, :style]
 

--- a/lib/chef_core/actions/install_chef.rb
+++ b/lib/chef_core/actions/install_chef.rb
@@ -26,6 +26,11 @@ module ChefCore
         super
       end
 
+      # We have not yet implemented install behaviors outside of these OSs
+      def supported_base_os_types
+        [:linux, :windows].freeze
+      end
+
       def perform_action
         if InstallChef::MinimumChefVersion.check!(target_host, config[:check_only]) == :minimum_version_met
           notify(:already_installed)

--- a/lib/chef_core/target_host.rb
+++ b/lib/chef_core/target_host.rb
@@ -92,7 +92,7 @@ module ChefCore
 
       # From WinRM gem: It is recommended that you :disable_sspi => true if you are using the plaintext or ssl transport.
       #                 See note here: https://github.com/mwrock/WinRM#example
-      if ["ssl", "plaintext"].include?(target_opts[:winrm_transport])
+      if %w{ssl plaintext}.include?(target_opts[:winrm_transport])
         target_opts[:winrm_disable_sspi] = true
       end
 
@@ -148,6 +148,9 @@ module ChefCore
       when :linux
         require "chef_core/target_host/linux"
         class << self; include ChefCore::TargetHost::Linux; end
+      when :unix
+        require "chef_core/target_host/unix"
+        class << self; include ChefCore::TargetHost::Unix; end
       when :windows
         require "chef_core/target_host/windows"
         class << self; include ChefCore::TargetHost::Windows; end
@@ -181,6 +184,8 @@ module ChefCore
         :windows
       elsif platform.linux?
         :linux
+      elsif platform.unix?
+        :unix
       else
         :other
       end
@@ -205,13 +210,13 @@ module ChefCore
 
     # TODO spec
     def save_as_remote_file(content, remote_path)
-       t = Tempfile.new("chef-content")
-       t << content
-       t.close
-       upload_file(t.path, remote_path)
+      t = Tempfile.new("chef-content")
+      t << content
+      t.close
+      upload_file(t.path, remote_path)
     ensure
-        t.close
-        t.unlink
+      t.close
+      t.unlink
     end
 
     def upload_file(local_path, remote_path)

--- a/lib/chef_core/target_host/unix.rb
+++ b/lib/chef_core/target_host/unix.rb
@@ -1,0 +1,16 @@
+
+
+module ChefCore
+  class TargetHost
+    module Unix
+      require "chef_core/target_host/linux"
+      # Most of our supported behaviors are the same on linux
+      include ChefCore::TargetHost::Linux
+
+      # This one is not, and is not supported yet.
+      def install_package(target_package_path)
+        raise NotImplementedError
+      end
+    end
+  end
+end

--- a/spec/unit/target_host_spec.rb
+++ b/spec/unit/target_host_spec.rb
@@ -37,6 +37,14 @@ RSpec.describe ChefCore::TargetHost do
       end
     end
 
+    context "for a unix os" do
+      let(:family) { "os" }
+      let(:name) { "mac_os_x" }
+      it "reports :unix" do
+        expect(subject.base_os).to eq :unix
+      end
+    end
+
     context "for a linux os" do
       let(:family) { "debian" }
       let(:name) { "ubuntu" }
@@ -111,6 +119,14 @@ RSpec.describe ChefCore::TargetHost do
       let(:base_os) { :windows }
       it "mixes in Windows support" do
         expect(subject.class).to receive(:include).with(ChefCore::TargetHost::Windows)
+        subject.mix_in_target_platform!
+      end
+    end
+
+    context "when base_os is unix" do
+      let(:base_os) { :unix }
+      it "mixes in Windows support" do
+        expect(subject.class).to receive(:include).with(ChefCore::TargetHost::Unix)
         subject.mix_in_target_platform!
       end
     end


### PR DESCRIPTION


## Description

This adds unix as a supported `TargetHost#base_os`. Install behavior is not implemented for unix - there is not yet need for it.
Because of this, `Actions::Base` has been updated with an overrideable
`supported_base_os_types` method. It defaults to all supported base OSes  Prior to running an action
`Base#run` will now check the target host's `base_os` against supported
platforms and raise UnsupportedTargetOS if the base OS is not supported
by the action.

InstallChef was updated to declare it supports only :windows and :linux.

Signed-off-by: Marc A. Paradise <marc.paradise@gmail.com>

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the **CONTRIBUTING** document.
- [x] I have run the pre-merge tests locally and they pass.
- [x] n/a ~I have updated the documentation accordingly.~
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
- [x] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
