### PR TITLE
Allow ruby 2.4, which InSpec allows

### DIFF
--- a/chef-core-actions.gemspec
+++ b/chef-core-actions.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.description = "Common functionality for Chef ruby components"
   spec.homepage    = "https://github.com/chef/chef_core"
   spec.license     = "Apache-2.0"
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.files = %w{ LICENSE lib/chef_core/actions.rb } +
     Dir.glob("{i18n,lib/chef_core/actions}/**/*", File::FNM_DOTMATCH)

--- a/chef-core.gemspec
+++ b/chef-core.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.description = "Composable common actions for assembling Chef workflows"
   spec.homepage    = "https://github.com/chef/chef_core"
   spec.license     = "Apache-2.0"
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = ">= 2.4.0"
 
   spec.files = %w{ LICENSE } +
     Dir.glob("{i18n,lib,resources}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) || f =~ /chef_core\/actions.*$/ }


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description

Chef InSpec is looking to rely on chef-core for telemetry support. However, InSpec allows Ruby v2.4 support; we'd like to loosen the constraint on chef-core to allow 2.4 as well.

I have not checked to see if chef-core uses any 2.5+ features. 

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
