### PR TITLE
Bump (down) supported ruby version to include ruby 2.4.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+<!-- latest_release -->
+<!-- latest_release -->
+
+<!-- release_rollup -->
+<!-- release_rollup -->
+
+<!-- latest_stable_release -->
+<!-- latest_stable_release -->
+

--- a/README.md
+++ b/README.md
@@ -351,4 +351,3 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
-

--- a/README.md
+++ b/README.md
@@ -351,3 +351,4 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 ```
+ 

--- a/Rakefile
+++ b/Rakefile
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-require "bundler/gem_tasks"
+# require "bundler/gem_tasks"
 
 task default: [:spec, :style]
 

--- a/chef-core.gemspec
+++ b/chef-core.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.description = "Composable common actions for assembling Chef workflows"
   spec.homepage    = "https://github.com/chef/chef_core"
   spec.license     = "Apache-2.0"
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = "~> 2.4.0"
 
   spec.files = %w{ LICENSE } +
     Dir.glob("{i18n,lib,resources}/**/*", File::FNM_DOTMATCH).reject { |f| File.directory?(f) || f =~ /chef_core\/actions.*$/ }

--- a/lib/chef_core/text/error_translation.rb
+++ b/lib/chef_core/text/error_translation.rb
@@ -26,14 +26,13 @@ module ChefCore
       def initialize(id, params: [])
         error_translation = error_translation_for_id(id)
 
-        options = YAML.load(Text.errors.display_defaults, "display_defaults",
-                            symbolize_names: true)
+        options = _sym(YAML.load(Text.errors.display_defaults, "display_defaults"))
 
         # Display metadata is a string containing a YAML hash that is optionally under
         # the error's 'options' attribute
         # Note that we couldn't use :display, as that conflicts with a method on Object.
         display_opts = if error_translation.methods.include?(:options)
-                         YAML.load(error_translation.options, @id, symbolize_names: true)
+                         _sym(YAML.load(error_translation.options, @id))
                        else
                          {}
                        end
@@ -51,6 +50,10 @@ module ChefCore
           # typos in attr names
           raise InvalidDisplayAttributes.new(id, options)
         end
+      end
+
+      def _sym hash
+        hash.map { |k,v| [k.to_sym, v] }.to_h
       end
 
       def inspect


### PR DESCRIPTION
Signed-off-by: Ryan Davis <zenspider@chef.io>