### PR TITLE
Remove reference to missing ChefCore::Config

### DIFF
--- a/lib/chef_core/telemeter/patch.rb
+++ b/lib/chef_core/telemeter/patch.rb
@@ -16,13 +16,6 @@
 #
 
 class Telemetry
-  class Session
-    # The telemetry session data is normally kept in .chef, which we don't have.
-    def session_file
-      ChefCore::Config.telemetry_session_file.freeze
-    end
-  end
-
   def deliver(data = {})
     if ChefCore::Telemeter.instance.enabled?
       payload = event.prepare(data)


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

The chef_core/telemeter/patch.rb contains a reference to `ChefCore::Config` to override the location of the telemetry session file. However, this class does not exist in ChefCore.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
