### PR TITLE
Make product information more flexible

### DIFF
--- a/lib/chef_core/telemeter/sender.rb
+++ b/lib/chef_core/telemeter/sender.rb
@@ -84,10 +84,11 @@ module ChefCore
         # We'll use the version captured in the sesion file
         entries = content["entries"]
         total = entries.length
-        telemetry = Telemetry.new(product: config.dig(:product, :name) || "chef-workstation",
-                                  origin: config.dig(:product, :origin) || "command-line",
-                                  product_version: config.dig(:product, :version) || content["version"],
-                                  install_context: config.dig(:product, :install_context) || "omnibus")
+        product_info = config[:product] || {}
+        telemetry = Telemetry.new(product: product_info[:name] || "chef-workstation",
+                                  origin: product_info[:origin] || "command-line",
+                                  product_version: product_info[:version] || content["version"],
+                                  install_context: product_info[:install_context] || "omnibus")
         total = entries.length
         entries.each_with_index do |entry, x|
           submit_entry(telemetry, entry, x + 1, total)

--- a/lib/chef_core/telemeter/sender.rb
+++ b/lib/chef_core/telemeter/sender.rb
@@ -83,12 +83,11 @@ module ChefCore
         FileUtils.rm_rf(config[:session_file])
         # We'll use the version captured in the sesion file
         entries = content["entries"]
-        cli_version = content["version"]
         total = entries.length
-        telemetry = Telemetry.new(product: "chef-workstation",
-                                  origin: "command-line",
-                                  product_version: cli_version,
-                                  install_context: "omnibus")
+        telemetry = Telemetry.new(product: config.dig(:product, :name) || "chef-workstation",
+                                  origin: config.dig(:product, :origin) || "command-line",
+                                  product_version: config.dig(:product, :version) || content["version"],
+                                  install_context: config.dig(:product, :install_context) || "omnibus")
         total = entries.length
         entries.each_with_index do |entry, x|
           submit_entry(telemetry, entry, x + 1, total)


### PR DESCRIPTION
Signed-off-by: Clinton Wolfe <clintoncwolfe@gmail.com>

<!--- Provide a short summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail, what problems does it solve? -->

This PR allows the consumer to set product information during setup, so that it will not be hardcoded during later submits.

Current code has chef-workstation hardcoded, and inspec needs to identify as itself.

## Related Issue
<!--- If you are suggesting a new feature or change, please create an issue first -->
<!--- Please link to the issue, discourse, or stackoverflow here: -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
